### PR TITLE
Remove publish config from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
     "url": "https://github.com/gopuff/timecapsule/issues"
   },
   "homepage": "https://github.com/gopuff/timecapsule#readme",
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/gopuff/"
-  },
   "scripts": {
     "test": "nyc --reporter=cobertura mocha",
     "lint": "eslint .",


### PR DESCRIPTION
This was causing the `npm publish` error:
```
npm ERR! Unable to authenticate, need: Basic realm="GitHub Package Registry"
```